### PR TITLE
[DRAFT] feat: Biblioteca de Prompts v1 + activar en hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ Hub web de herramientas de Infinity Hues. La raíz del proyecto ahora funciona c
 /
 ├── index.html                # Hub principal de Infinity Hues Tools
 ├── README.md
-└── playlist-timer/
-    ├── index.html            # Infinity Hues Playlist Timer
+├── playlist-timer/
+│   ├── index.html            # Infinity Hues Playlist Timer
+│   ├── styles.css
+│   └── script.js
+└── prompt-library/
+    ├── index.html            # Biblioteca de Prompts v1
     ├── styles.css
     └── script.js
 ```
@@ -31,11 +35,22 @@ Características actuales (sin cambios funcionales):
 - Persistencia en `localStorage`.
 - Botón **Copiar resumen** al portapapeles.
 
+
+### 2) Biblioteca de Prompts v1 (activa)
+Ruta: `/prompt-library/`
+
+Características actuales:
+- Alta, edición y eliminación de prompts.
+- Búsqueda por texto y filtro por categoría.
+- Persistencia completa en `localStorage`.
+- Exportación de la biblioteca a JSON descargable.
+- Importación de JSON para restaurar/reemplazar biblioteca.
+- Restauración de prompts de ejemplo.
+
 ### Próximas herramientas (en el hub)
 - Analizador de Ads
 - Tracker KDP
 - Biblioteca de Links
-- Biblioteca de Prompts
 
 ## Ejecutar localmente
 
@@ -53,6 +68,7 @@ Luego abre:
 
 - Hub: `http://localhost:8080/`
 - Playlist Timer: `http://localhost:8080/playlist-timer/`
+- Biblioteca de Prompts: `http://localhost:8080/prompt-library/`
 
 ## Despliegue
 

--- a/index.html
+++ b/index.html
@@ -346,14 +346,15 @@
         <p class="tool-description">Colección organizada de enlaces estratégicos para operar con foco y rapidez.</p>
       </article>
 
-      <article class="tool-card glass future" aria-disabled="true">
+      <a class="tool-card glass active" href="./prompt-library/">
         <div class="tool-top">
-          <span class="badge future">Próximamente</span>
+          <span class="badge active">Activa</span>
           <span class="tool-icon" aria-hidden="true">✨</span>
         </div>
         <h2>Biblioteca de Prompts</h2>
-        <p class="tool-description">Repositorio vivo de prompts probados para acelerar creatividad y ejecución.</p>
-      </article>
+        <p class="tool-description">Repositorio vivo de prompts probados para guardar, filtrar, exportar e importar en JSON.</p>
+        <span class="link-label">Abrir herramienta →</span>
+      </a>
     </section>
   </main>
 </body>

--- a/prompt-library/index.html
+++ b/prompt-library/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Infinity Hues Biblioteca de Prompts</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app-shell">
+    <header class="card app-header">
+      <div class="brand-block" aria-label="Logo Infinity Hues">
+        <div class="brand-logo" role="img" aria-label="IH">IH</div>
+        <div>
+          <h1>Biblioteca de Prompts v1</h1>
+          <p>Guarda, busca y reutiliza prompts sin depender de backend.</p>
+        </div>
+      </div>
+    </header>
+
+    <section class="grid-top">
+      <article class="card">
+        <h2 id="form-title">Nuevo prompt</h2>
+        <form id="prompt-form" novalidate>
+          <input id="prompt-id" type="hidden" />
+
+          <label for="prompt-title">Título</label>
+          <input id="prompt-title" name="title" type="text" placeholder="Ej. Reescribir texto de ventas" required />
+
+          <label for="prompt-category">Categoría</label>
+          <input id="prompt-category" name="category" type="text" placeholder="Ej. Marketing" />
+
+          <label for="prompt-tags">Tags (separados por coma)</label>
+          <input id="prompt-tags" name="tags" type="text" placeholder="copy, anuncio, conversion" />
+
+          <label for="prompt-content">Prompt</label>
+          <textarea id="prompt-content" name="content" rows="7" placeholder="Escribe el prompt aquí..." required></textarea>
+
+          <p id="form-message" class="form-message" role="alert" aria-live="polite"></p>
+
+          <div class="actions-row">
+            <button type="submit" class="btn primary">Guardar prompt</button>
+            <button type="button" id="cancel-edit" class="btn ghost hidden">Cancelar edición</button>
+          </div>
+        </form>
+      </article>
+
+      <article class="card">
+        <h2>Gestión de datos</h2>
+        <p class="helper">Todos los datos viven en <code>localStorage</code> del navegador.</p>
+        <div class="tool-actions">
+          <button id="export-json" type="button" class="btn secondary">Exportar JSON</button>
+          <label for="import-json" class="btn ghost label-btn">Importar JSON</label>
+          <input id="import-json" type="file" accept="application/json" />
+          <button id="reset-library" type="button" class="btn danger">Restaurar ejemplos</button>
+        </div>
+        <p id="import-message" class="helper" aria-live="polite"></p>
+      </article>
+    </section>
+
+    <section class="card">
+      <div class="list-header">
+        <h2>Prompts guardados</h2>
+        <span id="prompt-count" class="count-chip">0 prompts</span>
+      </div>
+
+      <div class="filters">
+        <input id="search-input" type="search" placeholder="Buscar por título, contenido o tags..." />
+        <input id="category-filter" type="search" placeholder="Filtrar por categoría..." />
+      </div>
+
+      <ul id="prompt-list" class="prompt-list"></ul>
+      <p id="empty-state" class="helper empty">No hay prompts todavía.</p>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/prompt-library/script.js
+++ b/prompt-library/script.js
@@ -155,6 +155,8 @@
             <p class="prompt-meta">Categoría: ${prompt.category || 'Sin categoría'} · Actualizado: ${formatDate(prompt.updatedAt)}</p>
           </div>
           <div class="prompt-actions">
+            <button type="button" class="btn ghost" data-action="copy" data-id="${prompt.id}">Copiar</button>
+            <button type="button" class="btn ghost" data-action="duplicate" data-id="${prompt.id}">Duplicar</button>
             <button type="button" class="btn ghost" data-action="edit" data-id="${prompt.id}">Editar</button>
             <button type="button" class="btn danger" data-action="delete" data-id="${prompt.id}">Eliminar</button>
           </div>
@@ -250,6 +252,44 @@
     setFormMessage('Prompt eliminado.', 'success');
   }
 
+
+  async function copyPromptById(id) {
+    const prompt = state.prompts.find((item) => item.id === id);
+    if (!prompt) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(prompt.content);
+      els.importMessage.textContent = `Prompt copiado: ${prompt.title}`;
+    } catch (error) {
+      els.importMessage.textContent = 'No se pudo copiar automáticamente. Copia manualmente el contenido.';
+    }
+  }
+
+  function duplicatePromptById(id) {
+    const prompt = state.prompts.find((item) => item.id === id);
+    if (!prompt) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const duplicate = {
+      ...prompt,
+      id: crypto.randomUUID(),
+      title: `Copia de ${prompt.title}`,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    state.prompts.unshift(duplicate);
+    saveState();
+    renderList();
+    fillForm(duplicate);
+    setFormMessage('Copia creada. Puedes editarla y guardarla.', 'success');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
   function exportJson() {
     const payload = {
       exportedAt: new Date().toISOString(),
@@ -327,6 +367,14 @@
       const id = target.getAttribute('data-id');
       if (!action || !id) {
         return;
+      }
+
+      if (action === 'copy') {
+        copyPromptById(id);
+      }
+
+      if (action === 'duplicate') {
+        duplicatePromptById(id);
       }
 
       if (action === 'edit') {

--- a/prompt-library/script.js
+++ b/prompt-library/script.js
@@ -1,0 +1,365 @@
+(function setupPromptLibrary() {
+  const STORAGE_KEY = 'infinity-hues-prompt-library-v1';
+  const hasDocument = typeof document !== 'undefined';
+
+  const SAMPLE_PROMPTS = [
+    {
+      id: crypto.randomUUID(),
+      title: 'Analiza este copy para anuncio',
+      category: 'Marketing',
+      tags: ['ads', 'copy', 'meta'],
+      content: 'Actúa como estratega de performance. Evalúa este copy para anuncio en Meta Ads y devuelve: 1) claridad del gancho, 2) objeciones no resueltas, 3) versión mejorada con CTA más fuerte. Texto: {{copy}}',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      title: 'Outline para ebook en KDP',
+      category: 'KDP',
+      tags: ['kdp', 'ebook', 'outline'],
+      content: 'Eres editor senior de no ficción. Crea un outline de 10 capítulos sobre {{tema}} para un ebook de 20,000 palabras. Incluye objetivo por capítulo, puntos clave y propuesta de título.',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+    {
+      id: crypto.randomUUID(),
+      title: 'Resumen ejecutivo de ideas',
+      category: 'Productividad',
+      tags: ['resumen', 'decisiones'],
+      content: 'Convierte estas notas sueltas en un resumen ejecutivo de máximo 8 bullets con lenguaje claro y orientado a decisión. Notas: {{notas}}',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ];
+
+  const state = {
+    prompts: [],
+    search: '',
+    categoryFilter: '',
+    editingId: null,
+  };
+
+  const getEl = (id) => (hasDocument ? document.getElementById(id) : null);
+
+  const els = {
+    form: getEl('prompt-form'),
+    formTitle: getEl('form-title'),
+    promptId: getEl('prompt-id'),
+    title: getEl('prompt-title'),
+    category: getEl('prompt-category'),
+    tags: getEl('prompt-tags'),
+    content: getEl('prompt-content'),
+    formMessage: getEl('form-message'),
+    cancelEdit: getEl('cancel-edit'),
+    exportJson: getEl('export-json'),
+    importJson: getEl('import-json'),
+    resetLibrary: getEl('reset-library'),
+    importMessage: getEl('import-message'),
+    searchInput: getEl('search-input'),
+    categoryFilter: getEl('category-filter'),
+    promptList: getEl('prompt-list'),
+    emptyState: getEl('empty-state'),
+    promptCount: getEl('prompt-count'),
+  };
+
+  function parseTags(value) {
+    return value
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+
+  function saveState() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ prompts: state.prompts }));
+  }
+
+  function normalizePrompt(prompt) {
+    const now = new Date().toISOString();
+
+    return {
+      id: typeof prompt.id === 'string' && prompt.id ? prompt.id : crypto.randomUUID(),
+      title: typeof prompt.title === 'string' ? prompt.title.trim() : '',
+      category: typeof prompt.category === 'string' ? prompt.category.trim() : '',
+      tags: Array.isArray(prompt.tags)
+        ? prompt.tags.map((tag) => String(tag).trim()).filter(Boolean)
+        : [],
+      content: typeof prompt.content === 'string' ? prompt.content.trim() : '',
+      createdAt: typeof prompt.createdAt === 'string' ? prompt.createdAt : now,
+      updatedAt: typeof prompt.updatedAt === 'string' ? prompt.updatedAt : now,
+    };
+  }
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        state.prompts = SAMPLE_PROMPTS.map((prompt) => ({ ...prompt }));
+        saveState();
+        return;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed.prompts)) {
+        throw new Error('Formato inválido');
+      }
+
+      const validPrompts = parsed.prompts
+        .map(normalizePrompt)
+        .filter((prompt) => prompt.title && prompt.content);
+
+      state.prompts = validPrompts.length ? validPrompts : SAMPLE_PROMPTS.map((prompt) => ({ ...prompt }));
+      saveState();
+    } catch (error) {
+      console.warn('No se pudo cargar la biblioteca, se usarán ejemplos.', error);
+      state.prompts = SAMPLE_PROMPTS.map((prompt) => ({ ...prompt }));
+      saveState();
+    }
+  }
+
+  function setFormMessage(message, type) {
+    els.formMessage.textContent = message;
+    els.formMessage.className = `form-message ${type || ''}`.trim();
+  }
+
+  function formatDate(value) {
+    try {
+      return new Date(value).toLocaleString('es-ES', { dateStyle: 'short', timeStyle: 'short' });
+    } catch (error) {
+      return value;
+    }
+  }
+
+  function getFilteredPrompts() {
+    const search = state.search.toLowerCase();
+    const category = state.categoryFilter.toLowerCase();
+
+    return state.prompts.filter((prompt) => {
+      const haystack = [prompt.title, prompt.content, prompt.tags.join(' '), prompt.category].join(' ').toLowerCase();
+      const matchesSearch = !search || haystack.includes(search);
+      const matchesCategory = !category || prompt.category.toLowerCase().includes(category);
+      return matchesSearch && matchesCategory;
+    });
+  }
+
+  function renderList() {
+    const filtered = getFilteredPrompts().sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+    els.promptList.innerHTML = '';
+
+    filtered.forEach((prompt) => {
+      const item = document.createElement('li');
+      item.className = 'prompt-item';
+      item.innerHTML = `
+        <div class="prompt-top">
+          <div>
+            <h3 class="prompt-title">${prompt.title}</h3>
+            <p class="prompt-meta">Categoría: ${prompt.category || 'Sin categoría'} · Actualizado: ${formatDate(prompt.updatedAt)}</p>
+          </div>
+          <div class="prompt-actions">
+            <button type="button" class="btn ghost" data-action="edit" data-id="${prompt.id}">Editar</button>
+            <button type="button" class="btn danger" data-action="delete" data-id="${prompt.id}">Eliminar</button>
+          </div>
+        </div>
+        <div class="prompt-tags">${prompt.tags.map((tag) => `<span class="tag">#${tag}</span>`).join('')}</div>
+        <p class="prompt-content">${prompt.content}</p>
+      `;
+      els.promptList.appendChild(item);
+    });
+
+    els.promptCount.textContent = `${filtered.length} prompt${filtered.length === 1 ? '' : 's'}`;
+    els.emptyState.style.display = filtered.length ? 'none' : 'block';
+  }
+
+  function clearForm() {
+    els.promptId.value = '';
+    els.title.value = '';
+    els.category.value = '';
+    els.tags.value = '';
+    els.content.value = '';
+    state.editingId = null;
+    els.formTitle.textContent = 'Nuevo prompt';
+    els.cancelEdit.classList.add('hidden');
+  }
+
+  function fillForm(prompt) {
+    els.promptId.value = prompt.id;
+    els.title.value = prompt.title;
+    els.category.value = prompt.category;
+    els.tags.value = prompt.tags.join(', ');
+    els.content.value = prompt.content;
+    state.editingId = prompt.id;
+    els.formTitle.textContent = 'Editar prompt';
+    els.cancelEdit.classList.remove('hidden');
+  }
+
+  function upsertPrompt(event) {
+    event.preventDefault();
+    const title = els.title.value.trim();
+    const content = els.content.value.trim();
+
+    if (!title || !content) {
+      setFormMessage('Título y prompt son obligatorios.', 'error');
+      return;
+    }
+
+    const now = new Date().toISOString();
+    const promptData = {
+      id: state.editingId || crypto.randomUUID(),
+      title,
+      category: els.category.value.trim(),
+      tags: parseTags(els.tags.value),
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const existingIndex = state.prompts.findIndex((prompt) => prompt.id === promptData.id);
+
+    if (existingIndex >= 0) {
+      promptData.createdAt = state.prompts[existingIndex].createdAt;
+      state.prompts[existingIndex] = promptData;
+      setFormMessage('Prompt actualizado correctamente.', 'success');
+    } else {
+      state.prompts.push(promptData);
+      setFormMessage('Prompt guardado correctamente.', 'success');
+    }
+
+    saveState();
+    clearForm();
+    renderList();
+  }
+
+  function editPromptById(id) {
+    const prompt = state.prompts.find((item) => item.id === id);
+    if (!prompt) {
+      return;
+    }
+
+    fillForm(prompt);
+    setFormMessage('');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function deletePromptById(id) {
+    state.prompts = state.prompts.filter((prompt) => prompt.id !== id);
+    if (state.editingId === id) {
+      clearForm();
+    }
+
+    saveState();
+    renderList();
+    setFormMessage('Prompt eliminado.', 'success');
+  }
+
+  function exportJson() {
+    const payload = {
+      exportedAt: new Date().toISOString(),
+      version: 1,
+      prompts: state.prompts,
+    };
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `biblioteca-prompts-${new Date().toISOString().slice(0, 10)}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    els.importMessage.textContent = 'JSON exportado correctamente.';
+  }
+
+  async function importJson(event) {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      const text = await file.text();
+      const data = JSON.parse(text);
+      if (!Array.isArray(data.prompts)) {
+        throw new Error('El JSON no contiene un array prompts.');
+      }
+
+      const importedPrompts = data.prompts
+        .map(normalizePrompt)
+        .filter((prompt) => prompt.title && prompt.content);
+
+      if (!importedPrompts.length) {
+        throw new Error('No hay prompts válidos para importar.');
+      }
+
+      state.prompts = importedPrompts;
+      saveState();
+      renderList();
+      clearForm();
+      setFormMessage('');
+      els.importMessage.textContent = `Importación exitosa: ${importedPrompts.length} prompts.`;
+    } catch (error) {
+      els.importMessage.textContent = `Error al importar JSON: ${error.message}`;
+    } finally {
+      event.target.value = '';
+    }
+  }
+
+  function resetWithExamples() {
+    state.prompts = SAMPLE_PROMPTS.map((prompt) => ({ ...prompt, id: crypto.randomUUID() }));
+    saveState();
+    renderList();
+    clearForm();
+    setFormMessage('');
+    els.importMessage.textContent = 'Biblioteca restaurada con prompts de ejemplo.';
+  }
+
+  function bindEvents() {
+    els.form.addEventListener('submit', upsertPrompt);
+    els.cancelEdit.addEventListener('click', () => {
+      clearForm();
+      setFormMessage('Edición cancelada.', 'success');
+    });
+
+    els.promptList.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      const action = target.getAttribute('data-action');
+      const id = target.getAttribute('data-id');
+      if (!action || !id) {
+        return;
+      }
+
+      if (action === 'edit') {
+        editPromptById(id);
+      }
+
+      if (action === 'delete') {
+        deletePromptById(id);
+      }
+    });
+
+    els.searchInput.addEventListener('input', (event) => {
+      state.search = event.target.value || '';
+      renderList();
+    });
+
+    els.categoryFilter.addEventListener('input', (event) => {
+      state.categoryFilter = event.target.value || '';
+      renderList();
+    });
+
+    els.exportJson.addEventListener('click', exportJson);
+    els.importJson.addEventListener('change', importJson);
+    els.resetLibrary.addEventListener('click', resetWithExamples);
+  }
+
+  function init() {
+    loadState();
+    bindEvents();
+    renderList();
+  }
+
+  if (hasDocument) {
+    init();
+  }
+})();

--- a/prompt-library/styles.css
+++ b/prompt-library/styles.css
@@ -1,0 +1,228 @@
+:root {
+  --bg: #12131a;
+  --card: rgba(255, 255, 255, 0.93);
+  --text: #202331;
+  --muted: #656b82;
+  --purple: #7e49ff;
+  --pink: #da5ec9;
+  --blue: #4c9dfc;
+  --green: #1ea971;
+  --red: #bc3157;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #eef1ff;
+  background: radial-gradient(circle at top right, #32204f 0%, #1c1e28 45%, #121319 100%);
+}
+
+.app-shell {
+  width: min(1120px, 92vw);
+  margin: 2rem auto 3rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: var(--card);
+  color: var(--text);
+  border-radius: 1.1rem;
+  padding: 1.1rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, .28);
+}
+
+.app-header { padding: 1.2rem 1.4rem; }
+.brand-block { display: flex; align-items: center; gap: 1rem; }
+.brand-logo {
+  width: 54px;
+  height: 54px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  color: white;
+  background: linear-gradient(145deg, var(--purple), var(--pink));
+}
+
+h1, h2, p { margin: 0; }
+h1 { font-size: clamp(1.2rem, 2.4vw, 1.6rem); }
+.app-header p { color: var(--muted); margin-top: .3rem; }
+
+.grid-top {
+  display: grid;
+  grid-template-columns: 1.2fr .8fr;
+  gap: 1rem;
+}
+
+form {
+  margin-top: .9rem;
+  display: grid;
+  gap: .82rem;
+}
+
+label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: .18rem;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid #ced3e5;
+  border-radius: .7rem;
+  padding: .66rem .72rem;
+  font-size: .96rem;
+  font-family: inherit;
+}
+
+textarea { resize: vertical; min-height: 170px; }
+
+input:focus,
+textarea:focus {
+  outline: 2px solid #bba3ff;
+  outline-offset: 1px;
+}
+
+.btn {
+  border: 0;
+  border-radius: .72rem;
+  padding: .62rem .9rem;
+  font-weight: 800;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  line-height: 1;
+}
+
+.btn.primary { color: white; background: linear-gradient(135deg, var(--purple), var(--pink)); }
+.btn.secondary { color: white; background: linear-gradient(145deg, var(--blue), var(--purple)); }
+.btn.ghost { color: var(--text); background: #eceff9; }
+.btn.danger { color: #7f1a37; background: #ffdbe6; }
+
+.hidden { display: none; }
+
+.actions-row,
+.tool-actions {
+  display: flex;
+  gap: .68rem;
+  flex-wrap: wrap;
+}
+
+.helper {
+  color: var(--muted);
+  font-size: .92rem;
+}
+
+.form-message {
+  min-height: 1.2em;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.form-message.error { color: var(--red); }
+.form-message.success { color: var(--green); }
+
+#import-json { display: none; }
+.label-btn { user-select: none; }
+
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .8rem;
+}
+
+.count-chip {
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #4f5471;
+  font-size: .84rem;
+  padding: .28rem .58rem;
+  font-weight: 700;
+}
+
+.filters {
+  margin-top: .82rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: .7rem;
+}
+
+.prompt-list {
+  list-style: none;
+  margin: .85rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: .72rem;
+}
+
+.prompt-item {
+  border: 1px solid #e7ebf8;
+  border-radius: .85rem;
+  padding: .8rem;
+  background: #fbfcff;
+  display: grid;
+  gap: .46rem;
+}
+
+.prompt-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: .7rem;
+}
+
+.prompt-title {
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.prompt-meta {
+  color: var(--muted);
+  font-size: .82rem;
+}
+
+.prompt-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.tag {
+  border-radius: 999px;
+  font-size: .75rem;
+  padding: .2rem .52rem;
+  background: #ecebff;
+  color: #5347a3;
+}
+
+.prompt-content {
+  white-space: pre-wrap;
+  color: #2b2e41;
+  margin: 0;
+  font-size: .92rem;
+}
+
+.prompt-actions {
+  display: flex;
+  gap: .5rem;
+}
+
+.prompt-actions .btn {
+  padding: .45rem .62rem;
+  font-size: .84rem;
+}
+
+.empty { margin-top: .8rem; }
+
+@media (max-width: 960px) {
+  .grid-top { grid-template-columns: 1fr; }
+  .filters { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
### Motivation
- Proveer una herramienta local para guardar y reutilizar prompts sin depender de backend ni servicios externos.
- Permitir transferencia de datos entre equipos/instancias mediante exportación e importación JSON.
- Integrar la herramienta en el hub principal para que sea accesible desde la raíz del proyecto.

### Description
- Se añadió la nueva herramienta en `prompt-library/` con `index.html`, `styles.css` y `script.js` que implementan UI, estilos y lógica frontend (CRUD, búsqueda y filtro por categoría) y usan `localStorage` para persistencia.
- Se incluyeron prompts de ejemplo para bootstrap, funciones para restaurar ejemplos, y soporte de exportar la biblioteca a JSON descargable e importar JSON validando la estructura antes de sobrescribir el estado.
- Se actualizó el hub (`index.html`) marcando la Biblioteca de Prompts como activa y enlazando a `./prompt-library/`, y se actualizó `README.md` con la nueva herramienta y ruta de acceso.

### Testing
- Se ejecutaron comprobaciones de sintaxis con `node --check prompt-library/script.js` y `node --check playlist-timer/script.js`, ambas pasaron correctamente.
- Se validó que los archivos HTML/CSS/JS nuevos estén presentes y que el flujo de carga inicial use los `SAMPLE_PROMPTS` cuando `localStorage` está vacío (ver `prompt-library/script.js`).
- No se requieren pruebas de backend ni integraciones externas porque la herramienta es totalmente estática y basada en `localStorage`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0340302c8330ba66fcf67669323e)